### PR TITLE
Fixes

### DIFF
--- a/include/ocilib.hpp
+++ b/include/ocilib.hpp
@@ -35,6 +35,8 @@
 #include <list>
 #include <vector>
 #include <iterator>
+#include <cstddef>
+
 
 extern "C"{
 #include "ocilib.h"
@@ -4938,8 +4940,8 @@ public:
 	typedef Collection<value_type> CollectionType;
 
 	typedef std::random_access_iterator_tag iterator_category;
-	typedef std::ptrdiff_t difference_type;
-	typedef std::ptrdiff_t distance_type;
+	typedef ptrdiff_t difference_type;
+	typedef ptrdiff_t distance_type;
 	typedef value_type* pointer;
 	typedef value_type& reference;
 

--- a/include/ocilib.hpp
+++ b/include/ocilib.hpp
@@ -4938,8 +4938,8 @@ public:
 	typedef Collection<value_type> CollectionType;
 
 	typedef std::random_access_iterator_tag iterator_category;
-	typedef ptrdiff_t difference_type;
-	typedef ptrdiff_t distance_type;
+	typedef std::ptrdiff_t difference_type;
+	typedef std::ptrdiff_t distance_type;
 	typedef value_type* pointer;
 	typedef value_type& reference;
 

--- a/include/ocilib_impl.hpp
+++ b/include/ocilib_impl.hpp
@@ -1591,7 +1591,8 @@ inline ostring Connection::GetService() const
 
 inline ostring Connection::GetServer() const
 {
-    return Check(OCI_GetServerName(*this));
+    const otext * txt = OCI_GetServerName(*this);
+    return Check((txt ? txt : ""));
 }
 
 inline ostring Connection::GetDomain() const


### PR DESCRIPTION
```c++
./include/ocilib.hpp:4941:10: error: ‘ptrdiff_t’ does not name a type
  typedef ptrdiff_t difference_type;
          ^
./include/ocilib.hpp:4942:10: error: ‘ptrdiff_t’ does not name a type
  typedef ptrdiff_t distance_type;
```
Missing include file <cstddef>. Alternatively use std::ptrdiff_t instead of ptrdiff_t

Core dump in GetServer() include/ocilib_impl.hpp:1594 when 